### PR TITLE
Clocking cleanup

### DIFF
--- a/PCXT.sdc
+++ b/PCXT.sdc
@@ -32,9 +32,6 @@ create_generated_clock -name peripheral_clock -source [get_pins $CLOCK_4_77] -di
 # SPLASH
 set_false_path -to [get_registers {PCXT:guest|splash_off}]
 
-# AUDIO
-set_false_path -to [get_registers {PCXT:guest|clk_cpu_ff_1 PCXT:guest|pclk_ff_1 PCXT:guest|clk_opl2_ff_1}]
-
 # UART
 set_false_path -from [get_clocks $CLOCK_CHIP] -to [get_clocks $CLOCK_UART]
 set_false_path -from [get_clocks $CLOCK_UART] -to [get_clocks $CLOCK_CHIP]

--- a/rtl/KFPC-XT/HDL/Chipset.sv
+++ b/rtl/KFPC-XT/HDL/Chipset.sv
@@ -4,7 +4,9 @@
 //
 // Based on KFPC-XT written by @kitune-san
 //
-module CHIPSET (
+module CHIPSET #(
+        parameter clk_rate = 28'd50000000)
+        (
         input   logic           clock,
         input   logic           cpu_clock,
         input   logic           clk_sys,
@@ -100,7 +102,6 @@ module CHIPSET (
         input   logic   [15:0]  joya0,
         input   logic   [15:0]  joya1,
         // JTOPL
-        input   logic           clk_en_opl2,
         output  logic   [15:0]  jtopl2_snd_e,
         input   logic   [1:0]   opl2_io,
         // C/MS Audio
@@ -274,7 +275,7 @@ module CHIPSET (
         .terminal_count_n                   (terminal_count_n)
     );
 
-    PERIPHERALS u_PERIPHERALS 
+    PERIPHERALS #(.clk_rate(clk_rate)) u_PERIPHERALS 
     (
         .clock                              (clock),
         .clk_sys                            (clk_sys),
@@ -347,7 +348,6 @@ module CHIPSET (
         .joya1                              (joya1),
         .ps2_clock_out                      (ps2_clock_out),
         .ps2_data_out                       (ps2_data_out),
-        .clk_en_opl2                        (clk_en_opl2),
         .jtopl2_snd_e                       (jtopl2_snd_e),
         .opl2_io                            (opl2_io),
         .cms_en                             (cms_en),
@@ -373,7 +373,6 @@ module CHIPSET (
         .ems_b2                            (ems_b2),
         .ems_b3                            (ems_b3),
         .ems_b4                            (ems_b4),
-        .clock_rate                         (clock_rate),
         .hdd_cmd_req                        (hdd_cmd_req),
         .hdd_dat_req                        (hdd_dat_req),
         .hdd_addr                           (hdd_addr),


### PR DESCRIPTION
- Remove some unnecessary clock domain crossings
- Generate the opl2_cen in the clk_chipset domain
- Fix the rate which used to calculate fractional CE's, SAA(CMS) tone pitch is now correct