### PR TITLE
Move IDE module to the top, enable slave IDE drive

### DIFF
--- a/rtl/KFPC-XT/HDL/Chipset.sv
+++ b/rtl/KFPC-XT/HDL/Chipset.sv
@@ -147,16 +147,12 @@ module CHIPSET #(
         input  logic    [1:0]   bios_protect_flag,
         //
         input   logic   [27:0]  clock_rate,
-        // Virtual HDD Bus
-        output  logic           hdd_cmd_req,
-        output  logic           hdd_dat_req,
-        input   logic   [2:0]   hdd_addr,
-        input   logic   [15:0]  hdd_data_out,
-        output  logic   [15:0]  hdd_data_in,
-        input   logic           hdd_wr,
-        input   logic           hdd_status_wr,
-        input   logic           hdd_data_wr,
-        input   logic           hdd_data_rd,
+        // Primary IDE Bus
+        output  logic    [3:0]  ide0_addr,
+        output  logic   [15:0]  ide0_writedata,
+        input   logic   [15:0]  ide0_readdata,
+        output  logic           ide0_read,
+        output  logic           ide0_write,
         // XTCTL DATA
         output  logic   [7:0]   xtctl,
         // Optional flags
@@ -373,15 +369,11 @@ module CHIPSET #(
         .ems_b2                            (ems_b2),
         .ems_b3                            (ems_b3),
         .ems_b4                            (ems_b4),
-        .hdd_cmd_req                        (hdd_cmd_req),
-        .hdd_dat_req                        (hdd_dat_req),
-        .hdd_addr                           (hdd_addr),
-        .hdd_data_out                       (hdd_data_out),
-        .hdd_data_in                        (hdd_data_in),
-        .hdd_wr                             (hdd_wr),
-        .hdd_status_wr                      (hdd_status_wr),
-        .hdd_data_wr                        (hdd_data_wr),
-        .hdd_data_rd                        (hdd_data_rd),
+        .ide0_addr                          (ide0_addr),
+        .ide0_writedata                     (ide0_writedata),
+        .ide0_readdata                      (ide0_readdata),
+        .ide0_read                          (ide0_read),
+        .ide0_write                         (ide0_write),
         .xtctl                              (xtctl),
         .pause_core                         (pause_core)
     );


### PR DESCRIPTION
The slave drive can be named as PCXT.HD1 on MiST. For DeMiSTified platforms, it might be required to recompile the firmware, and add a mount option to the OSD.